### PR TITLE
Bump undici and @sveltejs/kit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@playwright/test": "^1.37.0",
 				"@sveltejs/adapter-auto": "^2.1.0",
 				"@sveltejs/adapter-node": "^1.3.1",
-				"@sveltejs/kit": "^1.22.6",
+				"@sveltejs/kit": "^1.27.0",
 				"@types/cookie": "^0.5.1",
 				"@types/google.maps": "^3.53.6",
 				"@types/google.visualization": "^0.0.69",
@@ -487,6 +487,15 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
+		"node_modules/@fastify/busboy": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
+			"integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@fontsource/fira-mono": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/@fontsource/fira-mono/-/fira-mono-5.0.8.tgz",
@@ -818,9 +827,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.22.6",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.22.6.tgz",
-			"integrity": "sha512-SDKxI/QpsReCwIn5czjT53fKlPBybbmMk67d317gUqfeORroBAFN1Z6s/x0E1JYi+04i7kKllS+Sz9wVfmUkAQ==",
+			"version": "1.27.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.27.0.tgz",
+			"integrity": "sha512-a1wPIq2uO3RsTmV+KbA4venOgCJDbfHTXFe+g7eJR3N8l46DSuulUONJ1qnk2EnZWYC1Uj3Wbp3US0WFocIzXg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -831,11 +840,12 @@
 				"esm-env": "^1.0.0",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.0",
-				"mime": "^3.0.0",
+				"mrmime": "^1.0.1",
 				"sade": "^1.8.1",
 				"set-cookie-parser": "^2.6.0",
 				"sirv": "^2.0.2",
-				"undici": "~5.23.0"
+				"tiny-glob": "^0.2.9",
+				"undici": "~5.26.2"
 			},
 			"bin": {
 				"svelte-kit": "svelte-kit.js"
@@ -1550,18 +1560,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/busboy": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-			"dev": true,
-			"dependencies": {
-				"streamsearch": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=10.16.0"
 			}
 		},
 		"node_modules/cac": {
@@ -2448,6 +2446,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/globalyzer": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+			"integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+			"dev": true
+		},
 		"node_modules/globby": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -2467,6 +2471,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/globrex": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+			"dev": true
 		},
 		"node_modules/google-charts": {
 			"version": "2.0.0",
@@ -2889,18 +2899,6 @@
 			},
 			"engines": {
 				"node": ">=8.6"
-			}
-		},
-		"node_modules/mime": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-			"dev": true,
-			"bin": {
-				"mime": "cli.js"
-			},
-			"engines": {
-				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/min-indent": {
@@ -3867,15 +3865,6 @@
 			"integrity": "sha512-Rz6yejtVyWnVjC1RFvNmYL10kgjC49EOghxWn0RFqlCHGFpQx+Xe7yW3I4ceK1SGrWIGMjD5Kbue8W/udkbMJg==",
 			"dev": true
 		},
-		"node_modules/streamsearch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -4269,6 +4258,16 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/tiny-glob": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+			"integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+			"dev": true,
+			"dependencies": {
+				"globalyzer": "0.1.0",
+				"globrex": "^0.1.2"
+			}
+		},
 		"node_modules/tinybench": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.5.0.tgz",
@@ -4391,12 +4390,12 @@
 			"dev": true
 		},
 		"node_modules/undici": {
-			"version": "5.23.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz",
-			"integrity": "sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==",
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.26.5.tgz",
+			"integrity": "sha512-cSb4bPFd5qgR7qr2jYAi0hlX9n5YKK2ONKkLFkxl+v/9BvC0sOpZjBHDBSXc5lWAf5ty9oZdRXytBIHzgUcerw==",
 			"dev": true,
 			"dependencies": {
-				"busboy": "^1.6.0"
+				"@fastify/busboy": "^2.0.0"
 			},
 			"engines": {
 				"node": ">=14.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"@playwright/test": "^1.37.0",
 		"@sveltejs/adapter-auto": "^2.1.0",
 		"@sveltejs/adapter-node": "^1.3.1",
-		"@sveltejs/kit": "^1.22.6",
+		"@sveltejs/kit": "^1.27.0",
 		"@types/cookie": "^0.5.1",
 		"@types/google.maps": "^3.53.6",
 		"@types/google.visualization": "^0.0.69",


### PR DESCRIPTION
Bumps [undici](https://github.com/nodejs/undici) to 5.26.5 and updates ancestor dependency [@sveltejs/kit](https://github.com/sveltejs/kit/tree/HEAD/packages/kit). These dependencies need to be updated together.


Updates `undici` from 5.23.0 to 5.26.5
- [Release notes](https://github.com/nodejs/undici/releases)
- [Commits](https://github.com/nodejs/undici/compare/v5.23.0...v5.26.5)

Updates `@sveltejs/kit` from 1.22.6 to 1.27.0
- [Release notes](https://github.com/sveltejs/kit/releases)
- [Changelog](https://github.com/sveltejs/kit/blob/master/packages/kit/CHANGELOG.md)
- [Commits](https://github.com/sveltejs/kit/commits/@sveltejs/kit@1.27.0/packages/kit)

---
updated-dependencies:
- dependency-name: undici dependency-type: indirect
- dependency-name: "@sveltejs/kit" dependency-type: direct:development ...